### PR TITLE
chore: migrate from JitPack to Labs64 Nexus

### DIFF
--- a/checkout-be/pom.xml
+++ b/checkout-be/pom.xml
@@ -37,12 +37,7 @@
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
-        </repository>
-    </repositories>
+
 
     <dependencyManagement>
         <dependencies>
@@ -83,11 +78,11 @@
         </dependency>
 
         <!-- Trusted gateway auth-context: X-Auth-* parsing, fail-closed
-             enforcement and propagation. Served by JitPack from Labs64/labs64.io-commons. -->
+             enforcement and propagation. Served by Labs64 Nexus. -->
         <dependency>
-            <groupId>com.github.Labs64.labs64.io-commons</groupId>
+            <groupId>io.labs64</groupId>
             <artifactId>l64-auth-context-spring-boot-starter</artifactId>
-            <version>v0.1.0</version>
+            <version>0.1.1</version>
         </dependency>
         <!-- Micrometer Prometheus registry: serves /actuator/prometheus for the
              infrastructure-owned metrics scrape (matches auditflow). Java metrics stay on


### PR DESCRIPTION
Updates dependency to use io.labs64:l64-auth-context-spring-boot-starter:0.1.1 from Nexus, removing JitPack.